### PR TITLE
Boost performances on Yosemite by disabling NAT

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
         v.memory = 4096
         v.cpus = 2
+        v.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
+        v.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
     end
 
     config.vm.provider "lxc" do |lxc, override|


### PR DESCRIPTION
According to this thread, https://github.com/coreos/coreos-vagrant/issues/124#issuecomment-49481032, on some Yosemite versions with some VirtualBox versions, disabling NAT resolver boosts performances. I ran into this error today and it partly solved my issue.