### PR TITLE
Allow configuration of PostgreSQL database defaults

### DIFF
--- a/provisioning/roles/postgresql/defaults/main.yml
+++ b/provisioning/roles/postgresql/defaults/main.yml
@@ -1,3 +1,6 @@
 database_user: "{{ database_name }}"
 database_password: "{{ database_name }}"
 database_template: "template1"
+database_encoding: "UTF-8"
+database_lc_collate: "en_US.UTF-8"
+database_lc_ctype: "en_US.UTF-8"

--- a/provisioning/roles/postgresql/defaults/main.yml
+++ b/provisioning/roles/postgresql/defaults/main.yml
@@ -1,6 +1,6 @@
 database_user: "{{ database_name }}"
 database_password: "{{ database_name }}"
-database_template: "template1"
+database_template: "template0"
 database_encoding: "UTF-8"
 database_lc_collate: "en_US.UTF-8"
 database_lc_ctype: "en_US.UTF-8"

--- a/provisioning/roles/postgresql/tasks/main.yml
+++ b/provisioning/roles/postgresql/tasks/main.yml
@@ -23,6 +23,12 @@
   sudo: yes
 
 - name: create database
-  postgresql_db: name={{ database_name }} owner={{ database_user }} template={{ database_template }} state=present
+  postgresql_db: name={{ database_name }}
+                 owner={{ database_user }}
+                 template={{ database_template }}
+                 encoding={{ database_encoding }}
+                 lc_collate={{ database_lc_collate }}
+                 lc_ctype={{ database_lc_ctype }}
+                 state=present
   sudo_user: postgres
   sudo: yes


### PR DESCRIPTION
Without this, databases are created with:
* Encoding SQL_ASCII 
* Collate C 
* Ctype C

… which is not always possible for some applications.