### PR TITLE
[WIP] Introduce Gulp role with templates

### DIFF
--- a/provisioning/playbook.yml.dist
+++ b/provisioning/playbook.yml.dist
@@ -31,8 +31,11 @@
     # - { role: nginx }          # Nginx for basic HTML website
     # - { role: apache }         # Apache for basic HTML website
 
-    ## Install compass in the box
+    ## Install Compass in the box
     # - { role: compass }
+
+    ## Install Gulp with RAWBOT Gulpfile in the box
+    # - { role: gulp }
 
     ## Install Solr in the box
     # - { role: solr }

--- a/provisioning/roles/gulp/meta/main.yml
+++ b/provisioning/roles/gulp/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: nodejs }

--- a/provisioning/roles/gulp/tasks/main.yml
+++ b/provisioning/roles/gulp/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Create package.json and Gulpfile.js if non-existent
+  template: src={{ item.src }} dest={{ item.dest }} owner=root group=root mode=644 force=no
+  sudo: yes
+  with_items:
+    - { src: package.json, dest: /vagrant/package.json }
+    - { src: Gulpfile.js, dest: /vagrant/Gulpfile.js }
+
+- name: Install Gulp globally
+  shell: npm install -g gulp
+  sudo: yes
+
+- name: Install Node packages / Gulp dependencies
+  shell: npm install

--- a/provisioning/roles/gulp/templates/Gulpfile.js
+++ b/provisioning/roles/gulp/templates/Gulpfile.js
@@ -1,0 +1,76 @@
+////////////////////////////////////////////
+// RAWBOT Gulpfile
+// Version 0.2.0
+////////////////////////////////////////////
+
+'use strict';
+
+/**
+ * Load dependencies
+ */
+var gulp          = require('gulp'),
+    $             = require('gulp-load-plugins')(),
+    browserSync   = require('browser-sync').create(),
+    reload        = browserSync.reload;
+
+/**
+ * Configuration
+ */
+var config = {
+    src: {
+        sass:   'static/sass/**/*.scss',
+        images: 'static/images/**/*.{gif,jpg,jpeg,png,svg}',
+    },
+    dest: {
+        css:    'static/stylesheets',
+        images: 'static/images',
+    },
+    autoprefixer: {
+        browsers: ['last 2 versions', 'ie 9'],
+        cascade:  false,
+    },
+};
+
+
+/*----------------------------------------*\
+  TASKS
+\*----------------------------------------*/
+
+/**
+ * Watching files for changes
+ */
+gulp.task('watch', ['sass'], function() {
+    browserSync.init({
+        proxy: 'localhost'
+    });
+
+    gulp.watch(config.src.sass, ['sass']);
+});
+
+/**
+ * Compile Sass into CSS
+ * Add vendor prefixes with Autoprefixer
+ */
+gulp.task('sass', function() {
+    return gulp.src(config.src.sass)
+        .pipe($.sass({
+            outputStyle: 'compressed'
+        }).on('error', $.sass.logError))
+        .pipe($.autoprefixer(config.autoprefixer))
+        .pipe(gulp.dest(config.dest.css))
+        .pipe(reload({stream: true}));
+});
+
+/**
+ * Optimize images
+ */
+gulp.task('images', function () {
+    return gulp.src(config.src.images)
+        .pipe($.imagemin({
+            progressive: true,
+            svgoPlugins: [{removeViewBox: false}]
+        }))
+        .pipe(gulp.dest(config.dest.images));
+});
+
+gulp.task('default', ['watch']);

--- a/provisioning/roles/gulp/templates/package.json
+++ b/provisioning/roles/gulp/templates/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "project-name",
+  "version": "1.0.0",
+  "main": "README.md",
+  "author": "Liip AG",
+  "license": "private",
+  "private": true,
+  "devDependencies": {
+    "browser-sync": "^2.9.3",
+    "gulp": "^3.9.0",
+    "gulp-autoprefixer": "^2.3.1",
+    "gulp-imagemin": "^2.3.0",
+    "gulp-load-plugins": "^1.0.0-rc.1",
+    "gulp-sass": "^2.0.4"
+  }
+}


### PR DESCRIPTION
- [x] Create a role to install Gulp (with Node as a dependency) & packages defined in `package.json`
- [x] Copy templates (Gulpfile.js & package.json) when non-existent
- [ ] Move Gulp project specific config in an external YML or JSON file
- [ ] Test provisioning in a real project