### PR TITLE
Fixed xdebug file not found error.

### DIFF
--- a/provisioning/roles/php/templates/xdebug.ini.j2
+++ b/provisioning/roles/php/templates/xdebug.ini.j2
@@ -1,4 +1,4 @@
-zend_extension=/usr/lib/php5/20100525/xdebug.so
+zend_extension=/usr/lib/php5/20131226/xdebug.so
 
 xdebug.max_nesting_level=1000
 


### PR DESCRIPTION
The xdebug file is now at /usr/lib/php5/20131226/xdebug.so