### PR TITLE
NodeJS: use apt key from nodesource.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Changed
 
 - Django role: allow to disable virtualenv usage with `django_use_virtualenv` variable
+- NodeJS role: use apt key from nodesource.com instead of keyserver.ubuntu.com
 
 ## [2.1.0] - 2019-08-27
 

--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -9,7 +9,7 @@
   apt: pkg=apt-transport-https state=present
   become: yes
 - name: Add nodesource.com apt key
-  apt_key: id=68576280 url=https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280 state=present
+  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
   become: yes
 - name: Add nodesource.com apt repo
   apt_repository: repo='deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ nodejs_distro}} main' state=present update_cache=yes


### PR DESCRIPTION
keyserver.ubuntu.com is not responding (at least today), deb.nodesource.com seems to be the official place to grab the gpg key.